### PR TITLE
Feature/names

### DIFF
--- a/creator.sh
+++ b/creator.sh
@@ -7,7 +7,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE_IMAGE=""
 DOCKERFILE=""
-OUTPUT_NAME="widit-custom-distro"
+OUTPUT_NAME=""
 IMPORT_TO_WSL=false
 WSL_INSTALL_PATH=""
 
@@ -20,7 +20,7 @@ Usage: $0 [OPTIONS]
 Options:
     --base-image IMAGE      Use a Docker base image (e.g., ubuntu:22.04, alpine:latest)
     --dockerfile PATH       Build from a local Dockerfile
-    --output NAME          Output name for the distribution tarball (default: widit-custom-distro)
+    --output NAME          Output name for the distribution tarball (default: taken from base-image or dockerfile name)
     --import               Import the distribution into WSL after building
     --install-path PATH    WSL installation path (default: C:\\WSL\\{output-name})
     --help                 Show this help message
@@ -69,11 +69,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Set default install path if importing but no path specified
-if [[ "$IMPORT_TO_WSL" == true && -z "$WSL_INSTALL_PATH" ]]; then
-    WSL_INSTALL_PATH="C:\\WSL\\$OUTPUT_NAME"
-fi
-
 # Validate arguments
 if [[ -z "$BASE_IMAGE" && -z "$DOCKERFILE" ]]; then
     echo "Error: Either --base-image or --dockerfile must be specified"
@@ -85,6 +80,21 @@ if [[ -n "$BASE_IMAGE" && -n "$DOCKERFILE" ]]; then
     echo "Error: Cannot specify both --base-image and --dockerfile"
     show_help
     exit 1
+fi
+
+if [[ -n "$BASE_IMAGE" ]]; then
+    NAME_STEM="${BASE_IMAGE/:/-}"
+else
+    NAME_STEM="${DOCKERFILE%%.dockerfile}"
+fi
+
+if [[ -z "$OUTPUT_NAME" ]]; then
+    OUTPUT_NAME="widit-${NAME_STEM}"
+fi
+
+# Set default install path if importing but no path specified
+if [[ "$IMPORT_TO_WSL" == true && -z "$WSL_INSTALL_PATH" ]]; then
+    WSL_INSTALL_PATH="C:\\WSL\\$OUTPUT_NAME"
 fi
 
 # Check if Docker is available

--- a/creator.sh
+++ b/creator.sh
@@ -110,13 +110,13 @@ if [[ -n "$DOCKERFILE" ]]; then
         echo "Error: Dockerfile not found at $DOCKERFILE"
         exit 1
     fi
-    
+
     # Build the user's Dockerfile first to create a base image
     USER_IMAGE_TAG="widit-user-base:$(date +%s)"
     echo "Building user Dockerfile..."
     docker build --no-cache -f "$DOCKERFILE" -t "$USER_IMAGE_TAG" "$(dirname "$DOCKERFILE")"
     BASE_IMAGE="$USER_IMAGE_TAG"
-    
+
     # Set up cleanup for the user image
     cleanup_user_image() {
         echo "Cleaning up user base image..."
@@ -150,21 +150,21 @@ echo "WSL distribution created successfully: ${OUTPUT_NAME}.tar.gz"
 if [[ "$IMPORT_TO_WSL" == true ]]; then
     echo ""
     echo "Importing distribution into WSL..."
-    
+
     # Convert Unix path to Windows path for WSL command
     TARBALL_PATH="$(pwd)/${OUTPUT_NAME}.tar.gz"
     WINDOWS_TARBALL_PATH=$(wslpath -w "$TARBALL_PATH" 2>/dev/null || echo "$TARBALL_PATH")
-    
+
     # Remove existing distribution if it exists
     if wsl.exe -l -q | grep -q "^$OUTPUT_NAME$"; then
         echo "Removing existing distribution: $OUTPUT_NAME"
         wsl.exe --unregister "$OUTPUT_NAME"
     fi
-    
+
     # Import the distribution
     echo "Importing $OUTPUT_NAME to $WSL_INSTALL_PATH..."
     wsl.exe --import "$OUTPUT_NAME" "$WSL_INSTALL_PATH" "$WINDOWS_TARBALL_PATH"
-    
+
     echo "Distribution imported successfully!"
 else
     echo ""


### PR DESCRIPTION
Use the name given for base-image or dockerfile as default OUTPUT_NAME, so that careless runs result in (more) meaningful outputs